### PR TITLE
#95 : disable recipe top bar if recipe card disabled

### DIFF
--- a/src/components/cookingPage/recipeCards/RecipeCard.js
+++ b/src/components/cookingPage/recipeCards/RecipeCard.js
@@ -13,10 +13,7 @@ const RecipeCard = ({recipeData, onCardDelete, onCardEdit, onCardEnableDisable, 
 
     return (
         <div>
-            <div className={
-                `recipe-card-grid card
-                ${!recipeData.enabled ? "disabled-card": ""}
-            `}>
+            <div className={"recipe-card-grid card"}>
                 {createTopBar(recipeData, setPopup, onCardEnableDisable)}
                 {createRecipeCardBody(recipeData, setPopup, onMiniIngredientEditSaveClick)}
             </div>
@@ -55,7 +52,7 @@ function createTopBar(recipeData, setPopup, onCardEnableDisable) {
 function createRecipeCardBody(recipeData, setPopup, onMiniIngredientEditSaveClick) {
     return (
         <>
-            <div className={"recipe-img-div"}>
+            <div className={`recipe-img-div ${!recipeData.enabled ? "disabled-card": ""}`}>
                 <img
                     className={"recipe-img"}
                     style={{backgroundImage: 'url("./images/backgrounds/Rarity_' + recipeData.rarity + '_background_cropped.jpg")'}}
@@ -63,7 +60,7 @@ function createRecipeCardBody(recipeData, setPopup, onMiniIngredientEditSaveClic
                     alt={recipeData.name}
                 />
             </div>
-            <div className={"recipe-progress"}>
+            <div className={`recipe-progress ${!recipeData.enabled ? "disabled-card": ""}`}>
                 <span className={"progress-field prof-field"}>
                     <div className={"recipe-progress-fields"}>Proficiency :</div>
                     <p className={"recipe-data-field"}>{recipeData.currentProficiency}/{recipeData.rarity * 5}</p>
@@ -74,7 +71,7 @@ function createRecipeCardBody(recipeData, setPopup, onMiniIngredientEditSaveClic
                     <p className={"recipe-data-field"}>{recipeData.qty}/{recipeData.want}</p>
                 </span>
 
-                <div className={"cook-button-div"}>
+                <div className={`cook-button-div ${!recipeData.enabled ? "disabled-card": ""}`}>
                     <button
                         className={`modal-button`}
                         onClick={() => setPopup("cooking")}

--- a/src/components/cookingPage/shared/MiniIngredientCard.js
+++ b/src/components/cookingPage/shared/MiniIngredientCard.js
@@ -1,15 +1,15 @@
 import React, {useState} from 'react';
 import {MiniIngredientEditPopup} from "./MiniIngredientEditPopup";
 
-const MiniIngredientCard = ({ingredientData, qtyRequired, needsWarning = false, onEditSaveClick}) => {
+const MiniIngredientCard = ({ingredientData, qtyRequired, isEnabled = false, needsWarning = false, onEditSaveClick}) => {
     const [isEditClicked, setEditClicked] = useState(false);
     return (
         <div
             className={"mini-ingredient-container"}
         >
-            <div onClick={() => setEditClicked(true)}>
+            <div onClick={() => setEditClicked(true)} className={`${!isEnabled  ? "disabled-card" : ""}`}>
                 <img
-                    className={"mini-ingredient-card"}
+                    className={`mini-ingredient-card`}
                     src={ingredientData.src}
                     alt={ingredientData.name}
                     style={{backgroundImage: 'url("./images/backgrounds/Rarity_' + ingredientData.rarity + '_background_cropped.jpg")'}}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -792,7 +792,7 @@ input[type=number]::-webkit-outer-spin-button {
 }
 
 .disabled-button {
-  opacity: 60%;
+  opacity: 0.6;
   cursor: auto;
   &:hover {
     background-color: $z2-color;


### PR DESCRIPTION
- does not reduce opacity on top bar if recipe card is disabled
- fixes bug where mini ingredient cards were getting affected by the reduced opacity