### PR TITLE
Opacity bug 

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -146,7 +146,7 @@ body {
   flex-wrap: wrap;
 
   .disabled-card {
-    opacity: 60%;
+    opacity: 0.6;
   }
 
   .recipe-card-grid {


### PR DESCRIPTION
Percentages for opacity are not fully supported in all browsers. Updates recipe card disable style to use 0.6 instead of 60%