### PR TITLE
Fix for food recipe rank being set when it shouldn't

### DIFF
--- a/src/components/cookingPage/cookbook/RecipesContainer.js
+++ b/src/components/cookingPage/cookbook/RecipesContainer.js
@@ -47,12 +47,12 @@ function renderQuantityEditPopup(selectedRecipeCard, setSelectedRecipeCard, food
 function onAddNewRecipeSaveClick(recipeCard, currentProficiency, customQty, foodRecipes, setSelectedRecipeCard) {
     let numRecipesWithCard = foodRecipes.filter(recipe => recipe.hasCard).length;
 
-    recipeCard.rank = numRecipesWithCard === 0 ? 1 : numRecipesWithCard + 1;
-    recipeCard.currentProficiency = currentProficiency;
-    recipeCard.want = customQty;
     if (recipeCard.want !== 0) {
+        recipeCard.rank = numRecipesWithCard === 0 ? 1 : numRecipesWithCard + 1;
+        recipeCard.want = customQty;
         recipeCard.hasCard = true;
     }
+    recipeCard.currentProficiency = currentProficiency;
     storage.saveFoodRecipes(foodRecipes);
     setSelectedRecipeCard(null);
 }


### PR DESCRIPTION
#160
If a user has 0 desired qty for a food recipe, the recipe will not be assigned a rank, however users can still modify their current proficiencies